### PR TITLE
Hotfix for docker compilation proccess - gcc installation was added and numpy was installed separately

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.10-alpine
 WORKDIR /app
 COPY . .
-RUN pip install -r requirements.txt
+RUN apk update && \
+    apk add --no-cache gcc && \
+    pip install -r requirements.txt
 CMD ["python", "./main.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
+numpy
 pandas
 beautifulsoup4


### PR DESCRIPTION
Numpy library was installed separately because it might cause an issue. Gcc also was added to prevent possible compilation issues but this made the docker image larger